### PR TITLE
process.binding('evals') is deprecated, breaks on node 0.12.0

### DIFF
--- a/modules.js
+++ b/modules.js
@@ -9,7 +9,7 @@ var utils = require('./utils'),
     async = require('async'),
     path = require('path'),
     fs = require('fs'),
-    evals = process.binding('evals'),
+    evals = require('vm'),
     Script = evals.Script || evals.NodeScript;
 
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "async": "0.1.15",
         "mime": "1.2.4"
     },
-    "version": "0.1.6",
+    "version": "0.1.7",
     "repository": {
         "type": "git",
         "url": "http://github.com/kanso/kanso-utils.git"

--- a/utils.js
+++ b/utils.js
@@ -9,7 +9,7 @@ var path = require('path'),
     urlFormat = require('url').format,
     urlParse = require('url').parse,
     child_process = require('child_process'),
-    evals = process.binding('evals'),
+    evals = require('vm'),
     Script = evals.Script || evals.NodeScript;
 
 


### PR DESCRIPTION
process.binding('evals') is deprecated, breaks on node 0.12.0
